### PR TITLE
Fix for quick direction change

### DIFF
--- a/js/snake.js
+++ b/js/snake.js
@@ -115,8 +115,8 @@ SNAKE.Snake = SNAKE.Snake || (function() {
             playingBoard = config.playingBoard,
             myId = instanceNumber++,
             growthIncr = 5,
-            moveQueue = [], // a queue that holds the next moves of the snake
-            currentDirection = 1, // 0: up, 1: left, 2: down, 3: right
+            lastMove = 1;
+            currentDirection = -1, // 0: up, 1: left, 2: down, 3: right
             columnShift = [0, 1, 0, -1],
             rowShift = [-1, 0, 1, 0],
             xPosShift = [],
@@ -214,7 +214,7 @@ SNAKE.Snake = SNAKE.Snake || (function() {
         };
 
         /**
-        * This method is called when a user presses a key. It logs arrow key presses in "moveQueue", which is used when the snake needs to make its next move.
+        * This method is called when a user presses a key. It logs arrow key presses in "currentDirection", which is used when the snake needs to make its next move.
         * @method handleArrowKeys
         * @param {Number} keyNum A number representing the key that was pressed.
         */
@@ -229,7 +229,6 @@ SNAKE.Snake = SNAKE.Snake || (function() {
             if (isDead || isPaused) {return;}
 
             var snakeLength = me.snakeLength;
-            var lastMove = moveQueue[0] || currentDirection;
 
             //console.log("lastmove="+lastMove);
             //console.log("dir="+keyNum);
@@ -238,25 +237,25 @@ SNAKE.Snake = SNAKE.Snake || (function() {
                 case 37:
                 case 65:
                     if ( lastMove !== 1 || snakeLength === 1 ) {
-                        moveQueue.unshift(3); //SnakeDirection = 3;
+                        currentDirection = 3;
                     }
                     break;
                 case 38:
                 case 87:
                     if ( lastMove !== 2 || snakeLength === 1 ) {
-                        moveQueue.unshift(0);//SnakeDirection = 0;
+                        currentDirection = 0;
                     }
                     break;
                 case 39:
                 case 68:
                     if ( lastMove !== 3 || snakeLength === 1 ) {
-                        moveQueue.unshift(1); //SnakeDirection = 1;
+                        currentDirection = 1;
                     }
                     break;
                 case 40:
                 case 83:
                     if ( lastMove !== 0 || snakeLength === 1 ) {
-                        moveQueue.unshift(2);//SnakeDirection = 2;
+                        currentDirection = 2;
                     }
                     break;
             }
@@ -270,7 +269,6 @@ SNAKE.Snake = SNAKE.Snake || (function() {
 
             var oldHead = me.snakeHead,
                 newHead = me.snakeTail,
-                myDirection = currentDirection,
                 grid = playingBoard.grid; // cache grid for quicker lookup
 
             if (isPaused === true) {
@@ -286,14 +284,14 @@ SNAKE.Snake = SNAKE.Snake || (function() {
                 grid[newHead.row][newHead.col] = 0;
             }
 
-            if (moveQueue.length){
-                myDirection = currentDirection = moveQueue.pop();
+            if (currentDirection !== -1){
+                lastMove = currentDirection;
             }
 
-            newHead.col = oldHead.col + columnShift[myDirection];
-            newHead.row = oldHead.row + rowShift[myDirection];
-            newHead.xPos = oldHead.xPos + xPosShift[myDirection];
-            newHead.yPos = oldHead.yPos + yPosShift[myDirection];
+            newHead.col = oldHead.col + columnShift[lastMove];
+            newHead.row = oldHead.row + rowShift[lastMove];
+            newHead.xPos = oldHead.xPos + xPosShift[lastMove];
+            newHead.yPos = oldHead.yPos + yPosShift[lastMove];
 
             if ( !newHead.elmStyle ) {
                 newHead.elmStyle = newHead.elm.style;
@@ -365,7 +363,6 @@ SNAKE.Snake = SNAKE.Snake || (function() {
 
             isDead = true;
             playingBoard.handleDeath();
-            moveQueue.length = 0;
         };
 
         /**

--- a/js/snake.js
+++ b/js/snake.js
@@ -118,6 +118,7 @@ SNAKE.Snake = SNAKE.Snake || (function() {
             lastMove = 1,
             preMove = -1,
             isFirstMove = true,
+            isFirstGameMove = true,
             currentDirection = -1, // 0: up, 1: left, 2: down, 3: right
             columnShift = [0, 1, 0, -1],
             rowShift = [-1, 0, 1, 0],
@@ -259,10 +260,11 @@ SNAKE.Snake = SNAKE.Snake || (function() {
             {
                 preMove = directionFound;
             }
-            if (Math.abs(directionFound - lastMove) !== 2 && isFirstMove)  // Prevent snake from turning 180 degrees
+            if (Math.abs(directionFound - lastMove) !== 2 && isFirstMove || isFirstGameMove)  // Prevent snake from turning 180 degrees
             {
                 currentDirection = directionFound;
                 isFirstMove = false;
+                isFirstGameMove = false;
             }
         };
 
@@ -383,6 +385,7 @@ SNAKE.Snake = SNAKE.Snake || (function() {
         me.rebirth = function() {
             isDead = false;
             isFirstMove = true;
+            isFirstGameMove = true;
             preMove = -1;
         };
 

--- a/js/snake.js
+++ b/js/snake.js
@@ -115,7 +115,9 @@ SNAKE.Snake = SNAKE.Snake || (function() {
             playingBoard = config.playingBoard,
             myId = instanceNumber++,
             growthIncr = 5,
-            lastMove = 1;
+            lastMove = 1,
+            preMove = -1,
+            isFirstMove = true,
             currentDirection = -1, // 0: up, 1: left, 2: down, 3: right
             columnShift = [0, 1, 0, -1],
             rowShift = [-1, 0, 1, 0],
@@ -233,31 +235,34 @@ SNAKE.Snake = SNAKE.Snake || (function() {
             //console.log("lastmove="+lastMove);
             //console.log("dir="+keyNum);
 
+            let directionFound = -1;
+
             switch (keyNum) {
                 case 37:
                 case 65:
-                    if ( lastMove !== 1 || snakeLength === 1 ) {
-                        currentDirection = 3;
-                    }
+                    directionFound = 3;
                     break;
                 case 38:
                 case 87:
-                    if ( lastMove !== 2 || snakeLength === 1 ) {
-                        currentDirection = 0;
-                    }
+                    directionFound = 0;
                     break;
                 case 39:
                 case 68:
-                    if ( lastMove !== 3 || snakeLength === 1 ) {
-                        currentDirection = 1;
-                    }
+                    directionFound = 1;
                     break;
                 case 40:
                 case 83:
-                    if ( lastMove !== 0 || snakeLength === 1 ) {
-                        currentDirection = 2;
-                    }
+                    directionFound = 2;
                     break;
+            }
+            if (currentDirection !== lastMove)  // Allow a queue of 1 premove so you can turn again before the first turn registers
+            {
+                preMove = directionFound;
+            }
+            if (Math.abs(directionFound - lastMove) !== 2 && isFirstMove)  // Prevent snake from turning 180 degrees
+            {
+                currentDirection = directionFound;
+                isFirstMove = false;
             }
         };
 
@@ -286,7 +291,13 @@ SNAKE.Snake = SNAKE.Snake || (function() {
 
             if (currentDirection !== -1){
                 lastMove = currentDirection;
+                if (preMove !== -1)  // If the user queued up another move after the current one
+                {
+                    currentDirection = preMove;  // Execute that move next time (unless overwritten)
+                    preMove = -1;
+                }
             }
+            isFirstMove = true;
 
             newHead.col = oldHead.col + columnShift[lastMove];
             newHead.row = oldHead.row + rowShift[lastMove];
@@ -371,6 +382,8 @@ SNAKE.Snake = SNAKE.Snake || (function() {
         */
         me.rebirth = function() {
             isDead = false;
+            isFirstMove = true;
+            preMove = -1;
         };
 
         /**


### PR DESCRIPTION
Previously, quickly changing directions could make you in a situation where you're travelling in one direction, but think that you're going in another. This lets you do unintended things (like not be able to turn in one direction), as well as not register some keystrokes (very noticable on easy mode).

This has been very extensively tested; to test it yourself, I recommend playing on the `master` branch version on Hard, then making you screen size 3x10 and playing on Easy. You'll notice oftentimes you won't be able to turn at all, because you enter inputs too quickly, and the snake gets confused in your direction.

This fixes all of that. To test it, do the same thing but on `fix_input` branch and notice you'll be able to turn in time on Easy mode as well.

Closes #54 