### PR TITLE
Fix game crash when beating the game and add a win condition

### DIFF
--- a/css/dark-snake.css
+++ b/css/dark-snake.css
@@ -122,7 +122,7 @@ a.snake-link:hover {
     display: block;
 }
 
-.snake-try-again-dialog {
+.snake-try-again-dialog, .snake-win-dialog {
     padding: 8px;
     margin: 0px;
     background-color: black;
@@ -138,4 +138,4 @@ a.snake-link:hover {
     margin-left: -158px;
     text-align: center;
     display: none;
-    }
+}

--- a/css/green-snake.css
+++ b/css/green-snake.css
@@ -124,7 +124,7 @@ a.snake-link:hover {
     display: block;
 }
 
-.snake-try-again-dialog {
+.snake-try-again-dialog, .snake-win-dialog {
     padding: 8px;
     margin: 0px;
     background-color: #000000;
@@ -140,4 +140,4 @@ a.snake-link:hover {
     margin-left: -158px;
     text-align: center;
     display: none;
-    }
+}

--- a/css/light-snake.css
+++ b/css/light-snake.css
@@ -107,7 +107,7 @@ a.snake-link:hover {
     text-align: center;
     display: block;
 }
-.snake-try-again-dialog {
+.snake-try-again-dialog, .snake-win-dialog {
     padding: 8px;
     margin: 0px;
     background-color: #000000;

--- a/css/main-snake.css
+++ b/css/main-snake.css
@@ -119,7 +119,7 @@ a.snake-link:hover {
     display: block;
 }
 
-.snake-try-again-dialog {
+.snake-try-again-dialog, .snake-win-dialog {
     padding: 8px;
     margin: 0px;
     background-color: #000000;
@@ -135,4 +135,4 @@ a.snake-link:hover {
     margin-left: -158px;
     text-align: center;
     display: none;
-    }
+}

--- a/js/snake.js
+++ b/js/snake.js
@@ -751,48 +751,15 @@ SNAKE.Board = SNAKE.Board || (function() {
             return tmpElm;
         }
 
-        function createTryAgainElement() {
+        function createGameEndElement(message, elmId, elmClassName) {
             var tmpElm = document.createElement("div");
-            tmpElm.id = "sbTryAgain" + myId;
-            tmpElm.className = "snake-try-again-dialog";
+            tmpElm.id = elmId + myId;
+            tmpElm.className = elmClassName;
 
-            var tryAgainTxt = document.createElement("div");
-            tryAgainTxt.innerHTML = "JavaScript Snake<p></p>You died :(<p></p>";
-            var tryAgainStart = document.createElement("button");
-            tryAgainStart.appendChild( document.createTextNode("Play Again?"));
-
-            var reloadGame = function() {
-                tmpElm.style.display = "none";
-                me.resetBoard();
-                me.setBoardState(1);
-                me.getBoardContainer().focus();
-            };
-
-            var kbTryAgainShortcut = function(evt) {
-                if (boardState !== 0 || tmpElm.style.display !== "block") {return;}
-                if (!evt) var evt = window.event;
-                var keyNum = (evt.which) ? evt.which : evt.keyCode;
-                if (keyNum === 32 || keyNum === 13) {
-                    reloadGame();
-                }
-            };
-            SNAKE.addEventListener(window, "keyup", kbTryAgainShortcut, true);
-
-            SNAKE.addEventListener(tryAgainStart, "click", reloadGame, false);
-            tmpElm.appendChild(tryAgainTxt);
-            tmpElm.appendChild(tryAgainStart);
-            return tmpElm;
-        }
-
-        function createWinElement() {
-            var tmpElm = document.createElement("div");
-            tmpElm.id = "sbWin" + myId;
-            tmpElm.className = "snake-win-dialog";
-
-            var winTxt = document.createElement("div");
-            winTxt.innerHTML = "JavaScript Snake<p></p>You win! :D<p></p>";
-            var winStart = document.createElement("button");
-            winStart.appendChild(document.createTextNode("Play Again?"));
+            var gameEndTxt = document.createElement("div");
+            gameEndTxt.innerHTML = "JavaScript Snake<p></p>" + message + "<p></p>";
+            var gameEndStart = document.createElement("button");
+            gameEndStart.appendChild(document.createTextNode("Play Again?"));
 
             var reloadGame = function () {
                 tmpElm.style.display = "none";
@@ -801,7 +768,7 @@ SNAKE.Board = SNAKE.Board || (function() {
                 me.getBoardContainer().focus();
             };
 
-            var kbWinShortcut = function (evt) {
+            var kbGameEndShortcut = function (evt) {
                 if (boardState !== 0 || tmpElm.style.display !== "block") { return; }
                 if (!evt) var evt = window.event;
                 var keyNum = (evt.which) ? evt.which : evt.keyCode;
@@ -809,12 +776,20 @@ SNAKE.Board = SNAKE.Board || (function() {
                     reloadGame();
                 }
             };
-            SNAKE.addEventListener(window, "keyup", kbWinShortcut, true);
+            SNAKE.addEventListener(window, "keyup", kbGameEndShortcut, true);
 
-            SNAKE.addEventListener(winStart, "click", reloadGame, false);
-            tmpElm.appendChild(winTxt);
-            tmpElm.appendChild(winStart);
+            SNAKE.addEventListener(gameEndStart, "click", reloadGame, false);
+            tmpElm.appendChild(gameEndTxt);
+            tmpElm.appendChild(gameEndStart);
             return tmpElm;
+        }
+
+        function createTryAgainElement() {
+            return createGameEndElement("You died :(", "sbTryAgain", "snake-try-again-dialog");
+        }
+
+        function createWinElement() {
+            return createGameEndElement("You win! :D", "sbWin", "snake-win-dialog");
         }
 
         function handleEndCondition(elmDialog) {

--- a/js/snake.js
+++ b/js/snake.js
@@ -352,6 +352,8 @@ SNAKE.Snake = SNAKE.Snake || (function() {
         /**
         * This method is called when it is determined that the snake has eaten some food.
         * @method eatFood
+        * @return {bool} Whether a new food was able to spawn (true)
+        *   or not (false) after the snake eats food.
         */
         me.eatFood = function() {
             if (blockPool.length <= growthIncr) {
@@ -1019,6 +1021,8 @@ SNAKE.Board = SNAKE.Board || (function() {
         /**
         * This method is called when the snake has eaten some food.
         * @method foodEaten
+        * @return {bool} Whether a new food was able to spawn (true)
+        *   or not (false) after the snake eats food.
         */
         me.foodEaten = function() {
             elmLengthPanel.innerHTML = "Length: " + mySnake.snakeLength;


### PR DESCRIPTION
Fixed #55 by exiting out early from `randomlyPlaceFood` if it's determined that no more spots are available. If `randomlyPlaceFood` is called after snake eats food and it's determined that no more spots are available to place new food, then snake wins the game.

Beat the game on Firefox on a ~14x2 (around 14 width, 2 height) map to test. Both Win dialog and Try Again dialog will appear without issues. On Chrome and Safari, since it doesn't appear to be possible to make the window that small, I decided to just trigger the win condition upon collecting the first food to test to save time, but if it's a good idea to beat the game on these browsers as well then I can look into it. On Chrome and Safari, the Win dialog and Try again dialog will appear without issues as well.